### PR TITLE
feat: add fcmToken in login service

### DIFF
--- a/server/src/main/java/com/Gongdae9/user/domain/User.java
+++ b/server/src/main/java/com/Gongdae9/user/domain/User.java
@@ -27,6 +27,7 @@ public class User {
     private String accountId;
     private String password;
     private String statusMessage;
+    private String fcmToken;
 
     @Lob @Basic(fetch = FetchType.EAGER)
     private String profileImage;
@@ -67,4 +68,8 @@ public class User {
     }
 
     public void updateProfileImage(String base64Image){ this.profileImage = base64Image; }
+
+    public void updateFcmToken(String fcmToken) {
+        this.fcmToken = fcmToken;
+    }
 }

--- a/server/src/main/java/com/Gongdae9/user/dto/LoginRequestDto.java
+++ b/server/src/main/java/com/Gongdae9/user/dto/LoginRequestDto.java
@@ -6,9 +6,11 @@ import lombok.Data;
 public class LoginRequestDto {
     private String accountId;
     private String password;
+    private String fcmToken;
 
-    public LoginRequestDto(String accountId, String password) {
+    public LoginRequestDto(String accountId, String password, String fcmToken) {
         this.accountId = accountId;
         this.password = password;
+        this.fcmToken = fcmToken;
     }
 }

--- a/server/src/main/java/com/Gongdae9/user/service/UserService.java
+++ b/server/src/main/java/com/Gongdae9/user/service/UserService.java
@@ -43,11 +43,16 @@ public class UserService {
         return new UserDto(user);
     }
 
+    @Transactional
     public UserDto login(LoginRequestDto req,  HttpSession session) {
         User account = userRepository.findByAccountId(req.getAccountId()).get(0);
 
         if(!account.getPassword().equals(req.getPassword())){
             return null;
+        }
+
+        if(!account.getFcmToken().equals(req.getFcmToken())){
+            account.updateFcmToken(req.getFcmToken());
         }
 
         /* Save session information */
@@ -78,6 +83,7 @@ public class UserService {
         return false;
     }
 
+    @Transactional
     public boolean updateProfileImage(Long userId, String base64Image) {
         User user = userRepository.findById(userId);
         user.updateProfileImage(base64Image);

--- a/server/src/test/java/com/Gongdae9/loginSessionTest.java
+++ b/server/src/test/java/com/Gongdae9/loginSessionTest.java
@@ -2,6 +2,7 @@ package com.Gongdae9;
 
 import com.Gongdae9.user.domain.User;
 import com.Gongdae9.user.dto.LoginRequestDto;
+import com.Gongdae9.user.dto.UserDto;
 import com.Gongdae9.user.service.UserService;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -31,7 +32,8 @@ public class loginSessionTest {
             .build();
 
         //when
-        long createdUserId = userService.signUp(user);
+        UserDto userDto = userService.signUp(user);
+        Long createdUserId = userDto.getUserId();
 
         //then
         Long needCheckId = userService.findById(createdUserId).getUserId();
@@ -41,7 +43,7 @@ public class loginSessionTest {
     @Test
     public void 로그인_테스트() throws Exception {
         //given
-        LoginRequestDto dto = new LoginRequestDto("testid4", "testpw4");
+        LoginRequestDto dto = new LoginRequestDto("testid4", "testpw4", "testToken");
         MockHttpSession session = new MockHttpSession();
 
         //when


### PR DESCRIPTION
## 진행 사항

- 로그인 할 때, fcmToken을 전송하여 접속 디바이스를 검증한다.


- 만약 다른 토큰을 사용할 경우 유저 엔티티의 토큰을 변경시켜준다.